### PR TITLE
Fix issue with deleting all trash at once

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_API_URL="https://xnote-api.qridwan.com/api"
+#VITE_API_URL="http://localhost:8080/api"

--- a/src/components/trash/ConfirmModal.tsx
+++ b/src/components/trash/ConfirmModal.tsx
@@ -1,0 +1,47 @@
+import { Box, Button, Flex, Modal } from '@mantine/core';
+import { useDeleteAllTrashMutation } from '../../redux/features/trash/trashApi';
+import notify from '../../utils/notify';
+import { IconCheck, IconInfoTriangle } from '@tabler/icons-react';
+
+const ConfirmModal = ({ opened, setOpen }: {
+	opened: boolean,
+	setOpen: (s: boolean) => void
+}) => {
+
+	const [deleteAllTrash, { isLoading }] = useDeleteAllTrashMutation();
+
+	const handleDelete = async () => {
+		const resp: any = await deleteAllTrash({});
+
+		if (resp.data?.status === 'Success') {
+			setOpen(false);
+			notify(true, "All trashed notes deleted successfully!", <IconCheck />);
+
+		} else {
+			setOpen(false);
+			notify(false, "Failed to delete trashed notes!", <IconInfoTriangle />);
+		}
+	};
+
+	return (
+		<div>
+			<Modal
+				opened={opened}
+				onClose={() => !isLoading && setOpen(false)}
+				title="Extra caution required!"
+				transitionProps={{ transition: 'fade', duration: 600, timingFunction: 'linear' }}
+			>
+				<Box p={20}>
+					Are you sure you want to remove all trashed notes?
+
+					<Flex justify="flex-end" my={20} gap={20}>
+						<Button disabled={isLoading} variant="light" color='green' onClick={() => setOpen(false)}>Cancel</Button>
+						<Button disabled={isLoading} variant="gradient" gradient={{ from: 'red', to: '#ec8c69', deg: 35 }} onClick={handleDelete}>{isLoading ? "Deleting..." : "Delete"}</Button>
+					</Flex>
+				</Box>
+			</Modal>
+		</div>
+	);
+};
+
+export default ConfirmModal;

--- a/src/pages/Trash.tsx
+++ b/src/pages/Trash.tsx
@@ -1,11 +1,15 @@
-import { Container, Grid, ScrollArea, Text } from '@mantine/core';
+import { Button, Container, Flex, Grid, ScrollArea, Text } from '@mantine/core';
 
 import { useGettrashQuery } from '../redux/features/trash/trashApi';
 import TrashLists from '../components/List/TrashList';
+import { IconTrash } from '@tabler/icons-react';
+import ConfirmModal from '../components/trash/ConfirmModal';
+import { useState } from 'react';
 
 const Trash = () => {
 
 	const searchTerm = window.location.search.split('=')[1];
+	const [opened, setOpen] = useState(false);
 	const { data: allTrash, isLoading } = useGettrashQuery({ searchTerm: searchTerm }, { refetchOnMountOrArgChange: true, })
 
 
@@ -28,9 +32,14 @@ const Trash = () => {
 						</Grid.Col>
 					</Grid>
 					<ScrollArea h={'75vh'} type="never" >
-						<Text fz={30} align='center' color='grey' fw={800} my={30} inline>
-							Trash Box
-						</Text>
+						<Flex gap={20} justify={'center'} align={'center'}>
+							<Text fz={30} align='center' color='grey' fw={800} my={30} inline>
+								Trash Box
+							</Text>
+							{allTrash?.data?.length > 0 && <Button leftIcon={<IconTrash size="1rem" />} variant="gradient" gradient={{ from: '#ed6ea0', to: '#ec8c69', deg: 35 }} onClick={() => setOpen(true)}>Empty Trash</Button>}
+							<ConfirmModal opened={opened} setOpen={setOpen} />
+
+						</Flex>
 						<TrashLists type={'list'} notes={allTrash?.data} isLoading={isLoading} />
 					</ScrollArea>
 				</Grid.Col>

--- a/src/redux/features/trash/trashApi.ts
+++ b/src/redux/features/trash/trashApi.ts
@@ -20,6 +20,13 @@ const trashApi = api.injectEndpoints({
       }),
       invalidatesTags: ["trash", "notes"],
     }),
+    deleteAllTrash: builder.mutation({
+      query: () => ({
+        url: `/trash/permanent-delete-all`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["trash", "notes"],
+    }),
     addtrash: builder.mutation({
       query: (data: trashType) => ({
         url: `/trash/create`,
@@ -31,5 +38,9 @@ const trashApi = api.injectEndpoints({
   }),
 });
 
-export const { useDeletetrashMutation, useGettrashQuery, useAddtrashMutation } =
-  trashApi;
+export const {
+  useDeletetrashMutation,
+  useGettrashQuery,
+  useAddtrashMutation,
+  useDeleteAllTrashMutation,
+} = trashApi;


### PR DESCRIPTION
This pull request fixes the issue #12 by adding a new feature to delete all trashed notes at once. It includes changes to the ConfirmModal component and the Trash component. The ConfirmModal component now displays a confirmation modal when the "Empty Trash" button is clicked, and the Trash component now includes the ConfirmModal component and handles the deletion of all trashed notes.